### PR TITLE
Added darwin support

### DIFF
--- a/Linux/Demo/Linux_g++_binary_semaphore/makefile
+++ b/Linux/Demo/Linux_g++_binary_semaphore/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_binary_semaphore_no_except/makefile
+++ b/Linux/Demo/Linux_g++_binary_semaphore_no_except/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_NO_EXCEPTIONS
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_condition_variables/makefile
+++ b/Linux/Demo/Linux_g++_condition_variables/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_CONDITION_VARIABLES
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_condition_variables2/makefile
+++ b/Linux/Demo/Linux_g++_condition_variables2/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_CONDITION_VARIABLES
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_condition_variables_multiple_producers_consumers/makefile
+++ b/Linux/Demo/Linux_g++_condition_variables_multiple_producers_consumers/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_CONDITION_VARIABLES
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_condition_variables_multiple_producers_consumers2/main.cpp
+++ b/Linux/Demo/Linux_g++_condition_variables_multiple_producers_consumers2/main.cpp
@@ -81,6 +81,8 @@
 using namespace cpp_freertos;
 using namespace std;
 
+#define UNUSED(x) (void)(x)
+
 
 //
 //  Simple implementation of a bounded queue, to demonstrate
@@ -204,6 +206,7 @@ class ConsumerThread : public Thread {
         ConsumerThread(string name, int delay_seed)
            : Thread(name, 100, 1), DelaySeed(delay_seed), runIterations(0)
         {
+            UNUSED(DelaySeed);
             //
             //  Now that construction is completed, we
             //  can safely start the thread.

--- a/Linux/Demo/Linux_g++_condition_variables_multiple_producers_consumers2/makefile
+++ b/Linux/Demo/Linux_g++_condition_variables_multiple_producers_consumers2/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_CONDITION_VARIABLES
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_counting_semaphore/makefile
+++ b/Linux/Demo/Linux_g++_counting_semaphore/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_counting_semaphore_no_except/makefile
+++ b/Linux/Demo/Linux_g++_counting_semaphore_no_except/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_NO_EXCEPTIONS
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_critical_section/makefile
+++ b/Linux/Demo/Linux_g++_critical_section/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_delay_until/makefile
+++ b/Linux/Demo/Linux_g++_delay_until/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_dynamic_tasks/makefile
+++ b/Linux/Demo/Linux_g++_dynamic_tasks/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_dynamic_tasks_high_pri/makefile
+++ b/Linux/Demo/Linux_g++_dynamic_tasks_high_pri/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_dynamic_tasks_multistart_scheduler_off/makefile
+++ b/Linux/Demo/Linux_g++_dynamic_tasks_multistart_scheduler_off/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_dynamic_tasks_multistart_scheduler_on/makefile
+++ b/Linux/Demo/Linux_g++_dynamic_tasks_multistart_scheduler_on/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_mem_pools/makefile
+++ b/Linux/Demo/Linux_g++_mem_pools/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_mem_pools_add/makefile
+++ b/Linux/Demo/Linux_g++_mem_pools_add/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_mem_pools_static/makefile
+++ b/Linux/Demo/Linux_g++_mem_pools_static/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_mutex_recursive/makefile
+++ b/Linux/Demo/Linux_g++_mutex_recursive/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_mutex_recursive_no_except/makefile
+++ b/Linux/Demo/Linux_g++_mutex_recursive_no_except/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g 
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_NO_EXCEPTIONS
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_mutex_standard/makefile
+++ b/Linux/Demo/Linux_g++_mutex_standard/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_mutex_standard_no_except/makefile
+++ b/Linux/Demo/Linux_g++_mutex_standard_no_except/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g 
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_NO_EXCEPTIONS
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_queues_multiple_producers/makefile
+++ b/Linux/Demo/Linux_g++_queues_multiple_producers/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_queues_multiple_producers_multiple_consumers/makefile
+++ b/Linux/Demo/Linux_g++_queues_multiple_producers_multiple_consumers/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_queues_multiple_producers_multiple_consumers_no_except/makefile
+++ b/Linux/Demo/Linux_g++_queues_multiple_producers_multiple_consumers_no_except/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_NO_EXCEPTIONS
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_queues_multiple_producers_no_except/makefile
+++ b/Linux/Demo/Linux_g++_queues_multiple_producers_no_except/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_NO_EXCEPTIONS
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_queues_simple_producer_consumer/makefile
+++ b/Linux/Demo/Linux_g++_queues_simple_producer_consumer/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_queues_simple_producer_consumer_no_except/makefile
+++ b/Linux/Demo/Linux_g++_queues_simple_producer_consumer_no_except/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_NO_EXCEPTIONS
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_read_write_lock_prefer_reader/makefile
+++ b/Linux/Demo/Linux_g++_read_write_lock_prefer_reader/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_read_write_lock_prefer_reader_no_except/makefile
+++ b/Linux/Demo/Linux_g++_read_write_lock_prefer_reader_no_except/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_NO_EXCEPTIONS
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_read_write_lock_prefer_writer/makefile
+++ b/Linux/Demo/Linux_g++_read_write_lock_prefer_writer/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_read_write_lock_prefer_writer_no_except/makefile
+++ b/Linux/Demo/Linux_g++_read_write_lock_prefer_writer_no_except/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_NO_EXCEPTIONS
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_simple_tasks/makefile
+++ b/Linux/Demo/Linux_g++_simple_tasks/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_simple_tasks_no_cpp_strings/makefile
+++ b/Linux/Demo/Linux_g++_simple_tasks_no_cpp_strings/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_NO_CPP_STRINGS -DCPP_FREERTOS_NO_EXCEPTIONS
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_simple_tasks_no_vTaskDelete/makefile
+++ b/Linux/Demo/Linux_g++_simple_tasks_no_vTaskDelete/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_simple_tasks_no_vTaskDelete/makefile.cpp11
+++ b/Linux/Demo/Linux_g++_simple_tasks_no_vTaskDelete/makefile.cpp11
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -std=c++11
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_task_delete/makefile
+++ b/Linux/Demo/Linux_g++_task_delete/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_tasklet_dtor/main.cpp
+++ b/Linux/Demo/Linux_g++_tasklet_dtor/main.cpp
@@ -78,6 +78,8 @@
 using namespace cpp_freertos;
 using namespace std;
 
+#define UNUSED(x) (void)(x)
+
 
 
 class TestTasklet : public Tasklet {
@@ -144,6 +146,7 @@ class TestThread : public Thread {
         TestThread()
            : Thread("Thread", 100, configMAX_PRIORITIES - 1)
         {
+            UNUSED(DelayInSeconds);
             Start();
         };
 

--- a/Linux/Demo/Linux_g++_tasklet_dtor/makefile
+++ b/Linux/Demo/Linux_g++_tasklet_dtor/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_tasklet_dtor_no_except/main.cpp
+++ b/Linux/Demo/Linux_g++_tasklet_dtor_no_except/main.cpp
@@ -78,7 +78,7 @@
 using namespace cpp_freertos;
 using namespace std;
 
-
+#define UNUSED(x) (void)(x)
 
 class TestTasklet : public Tasklet {
 
@@ -144,6 +144,7 @@ class TestThread : public Thread {
         TestThread()
            : Thread("Thread", 100, configMAX_PRIORITIES - 1)
         {
+            UNUSED(DelayInSeconds);
             Start();
         };
 

--- a/Linux/Demo/Linux_g++_tasklet_dtor_no_except/makefile
+++ b/Linux/Demo/Linux_g++_tasklet_dtor_no_except/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_NO_EXCEPTIONS
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_tasklets/makefile
+++ b/Linux/Demo/Linux_g++_tasklets/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_tasklets_no_except/makefile
+++ b/Linux/Demo/Linux_g++_tasklets_no_except/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_NO_EXCEPTIONS
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_tickhook_disable/makefile
+++ b/Linux/Demo/Linux_g++_tickhook_disable/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_tickhooks/makefile
+++ b/Linux/Demo/Linux_g++_tickhooks/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_timers/makefile
+++ b/Linux/Demo/Linux_g++_timers/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_timers_no_except/makefile
+++ b/Linux/Demo/Linux_g++_timers_no_except/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_NO_EXCEPTIONS
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_unnamed_tasks/makefile
+++ b/Linux/Demo/Linux_g++_unnamed_tasks/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_unnamed_tasks_no_cpp_strings/makefile
+++ b/Linux/Demo/Linux_g++_unnamed_tasks_no_cpp_strings/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g -DCPP_FREERTOS_NO_CPP_STRINGS -DCPP_FREERTOS_NO_EXCEPTIONS
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_workqueues/makefile
+++ b/Linux/Demo/Linux_g++_workqueues/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_g++_workqueues_delete/makefile
+++ b/Linux/Demo/Linux_g++_workqueues_delete/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -80,7 +81,6 @@ CXX = g++
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 CXXFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/Linux_gcc_simple_tasks/makefile
+++ b/Linux/Demo/Linux_gcc_simple_tasks/makefile
@@ -66,6 +66,7 @@
 #   information accuracy).
 #   
 #############################################################################
+include ../os_specific_linker_options.mk
 
 FREERTOS_SRC_DIR=../../../../FreeRTOS/Source
 FREERTOS_INC_DIR=../../../../FreeRTOS/Source/include
@@ -76,7 +77,6 @@ PORTABLE_SRC_MEM_MANG_DIR=../../../../FreeRTOS/Source/portable/MemMang
 CC = gcc
 
 CFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
-LDFLAGS += -Wall -Werror -Wextra -Wpedantic -pthread -O0 -g
 
 
 

--- a/Linux/Demo/os_specific_linker_options.mk
+++ b/Linux/Demo/os_specific_linker_options.mk
@@ -1,0 +1,9 @@
+# DETECT OS
+OS := $(shell uname)
+
+LDFLAGS += -Wall -Werror -Wextra -Wpedantic -O0 -g
+
+ifneq ($(OS), Darwin)
+# You cannot use the -pthread flag when linking in Darwin
+LDFLAGS += -pthread
+endif


### PR DESCRIPTION
Hi,

I've added some functions to your port to get it to compile on Darwin (OSX) systems. Mainly this just involved creating a few functions you get in Linux and changing a few printf's to use the right types. All of these changes are wrapped in an #ifdef which is only defined if __APPLE__ or __MACH__ are defined by the system. I also added an UNUSED macro which you can wrap unused vars in to deal with compiler errors.

The one 'annoying' change is that clang doesn't like -pthread in the linker flags, so i had to remove this for darwin builds. Rather than put the logic to deal with this in to every demo makefile i broke it out into an include and added this file to all the makefiles instead.

After doing these things build_all.sh works perfectly on osx and all the demo programs build and run.
