### PR TITLE
Add workaround to prevent assert failure when there's nobody to yield to

### DIFF
--- a/Linux/portable/GCC/Linux/port.c
+++ b/Linux/portable/GCC/Linux/port.c
@@ -738,11 +738,23 @@ void vPortYield( void )
     assert(rc == 0);
 
     success = LookupThread(xTaskGetCurrentTaskHandle(), &ThreadToSuspend);
+    if (success != 1) {
+        printf("Nobody to suspend\n");
+        /* Yielding to self */
+        pthread_mutex_unlock( &xSingleThreadMutex );
+        return;
+    }
     assert(success);
 
     vTaskSwitchContext();
 
     success = LookupThread(xTaskGetCurrentTaskHandle(), &ThreadToResume);
+    if (success != 1) {
+        printf("Nobody to resume\n");
+        /* Yielding to self */
+        pthread_mutex_unlock( &xSingleThreadMutex );
+        return;
+    }
     assert(success);
 
     if ( !pthread_equal(ThreadToSuspend, ThreadToResume) )

--- a/c/Source/include/workqueue.h
+++ b/c/Source/include/workqueue.h
@@ -76,11 +76,13 @@ typedef void * WorkQueue_t;
  *  @param Name The name of the worker thread.
  *  @param StackSize The size of the worker thread stack, in words.
  *  @param Priority The priority of the worker thread.
+ *  @param core The core the task should be pinned to.
  *  @return A handle, or NULL on error.
  */
 WorkQueue_t CreateWorkQueueEx(  const char * const Name,
                                 uint16_t StackSize,
-                                UBaseType_t Priority);
+                                UBaseType_t Priority,
+                                BaseType_t core);
 
 
 /**

--- a/c/Source/workqueue.c
+++ b/c/Source/workqueue.c
@@ -254,7 +254,8 @@ static void WorkerThread(void *parameters)
 
 WorkQueue_t CreateWorkQueueEx(  const char * const Name,
                                 uint16_t StackSize,
-                                UBaseType_t Priority)
+                                UBaseType_t Priority,
+                                BaseType_t core)
 {
     /****************************/
     pvtWorkQueue_t *WorkQueue;
@@ -289,12 +290,14 @@ WorkQueue_t CreateWorkQueueEx(  const char * const Name,
 
 #endif
 
-    rc = xTaskCreate(   WorkerThread,
+    rc = xTaskCreatePinnedToCore(   WorkerThread,
                         Name,
                         StackSize,
                         WorkQueue,
                         Priority,
-                        &WorkQueue->WorkerThread);
+                        &WorkQueue->WorkerThread,
+                        core
+                        );
 
     if (rc != pdPASS) {
         vSemaphoreDelete(WorkQueue->Lock);


### PR DESCRIPTION
This can occur when the scheduler is being stopped. 