### PR TITLE
Reset the signal mask to its original state when scheduler exits

### DIFF
--- a/Linux/portable/GCC/Linux/port.c
+++ b/Linux/portable/GCC/Linux/port.c
@@ -612,6 +612,7 @@ portBASE_TYPE xPortStartScheduler( void )
     printf("[%d] Canceling xTaskEndScheduler caller thread.\n", hEndSchedulerCallerThreadIndex);
 #endif
 
+    pthread_sigmask(SIG_SETMASK, &xSignalsBlocked, NULL);
     pthread_cancel(hEndSchedulerCallerThread);
     sleep(1);
 


### PR DESCRIPTION
This allows the scheduler to be stopped and restarted again afterwards.