### PR TITLE
Add portYIELD_FROM_ISR as a macro refering to vPortYieldFromISR()

### DIFF
--- a/Linux/portable/GCC/Linux/portmacro.h
+++ b/Linux/portable/GCC/Linux/portmacro.h
@@ -115,6 +115,7 @@ extern void vPortYieldFromISR( void );
 extern void vPortYield( void );
 
 #define portYIELD()					vPortYield()
+#define portYIELD_FROM_ISR( x ) 			vPortYieldFromISR()
 
 #define portEND_SWITCHING_ISR( xSwitchRequired ) if( xSwitchRequired ) vPortYieldFromISR()
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Define `portYIELD_FROM_ISR` in the Linux port.  This function is used in numerous FreeRTOS examples, e.g. https://www.freertos.org/vTaskNotifyGiveFromISR.html.