### PR TITLE
fix: enqueue item should be passed as const

### DIFF
--- a/c++/Source/cqueue.cpp
+++ b/c++/Source/cqueue.cpp
@@ -63,7 +63,7 @@ Queue::~Queue()
 }
 
 
-bool Queue::Enqueue(void *item)
+bool Queue::Enqueue(const void *item)
 {
     BaseType_t success;
 
@@ -73,7 +73,7 @@ bool Queue::Enqueue(void *item)
 }
 
 
-bool Queue::Enqueue(void *item, TickType_t Timeout)
+bool Queue::Enqueue(const void *item, TickType_t Timeout)
 {
     BaseType_t success;
 
@@ -103,7 +103,7 @@ bool Queue::Peek(void *item, TickType_t Timeout)
 }
 
 
-bool Queue::EnqueueFromISR(void *item, BaseType_t *pxHigherPriorityTaskWoken)
+bool Queue::EnqueueFromISR(const void *item, BaseType_t *pxHigherPriorityTaskWoken)
 {
     BaseType_t success;
 

--- a/c++/Source/include/queue.hpp
+++ b/c++/Source/include/queue.hpp
@@ -141,7 +141,7 @@ class Queue {
          *  @param item The item you are adding.
          *  @return true if the item was added, false if it was not.
          */
-        virtual bool Enqueue(void *item);
+        virtual bool Enqueue(const void *item);
 
         /**
          *  Add an item to the back of the queue.
@@ -151,7 +151,7 @@ class Queue {
          *         the queue is currently full.
          *  @return true if the item was added, false if it was not.
          */
-        virtual bool Enqueue(void *item, TickType_t Timeout);
+        virtual bool Enqueue(const void *item, TickType_t Timeout);
 
         /**
          *  Remove an item from the front of the queue.
@@ -182,7 +182,7 @@ class Queue {
          *         rescheduling event.
          *  @return true if the item was added, false if it was not.
          */
-        virtual bool EnqueueFromISR(void *item, BaseType_t *pxHigherPriorityTaskWoken);
+        virtual bool EnqueueFromISR(const void *item, BaseType_t *pxHigherPriorityTaskWoken);
 
         /**
          *  Remove an item from the front of the queue in ISR context.


### PR DESCRIPTION
Looking deeper into the logic of freeRTOS enqueue, the `item` gets mem-copied into the queue buffer, so it is **safer** to pass it by const - making user sure, that the pointed **value will not** be changed.