### PR TITLE
PlatformIO support / ESP32, ESP32-S3 FreeRTOS support

### DIFF
--- a/c++/Source/ctickhook.cpp
+++ b/c++/Source/ctickhook.cpp
@@ -59,33 +59,63 @@ TickHook::TickHook()
 
 TickHook::~TickHook()
 {
-    taskENTER_CRITICAL();
-    Callbacks.remove(this);
-    taskEXIT_CRITICAL();
+    #ifdef ESP_PLATFORM
+        portMUX_TYPE mux;
+        taskENTER_CRITICAL(&mux);
+        Callbacks.remove(this);
+        taskEXIT_CRITICAL(&mux);
+    #else
+        taskENTER_CRITICAL();
+        Callbacks.remove(this);
+        taskEXIT_CRITICAL();
+    #endif
 }
 
 
 void TickHook::Register()
 {
-    taskENTER_CRITICAL();
-    Callbacks.push_front(this);
-    taskEXIT_CRITICAL();
+    #ifdef ESP_PLATFORM
+        portMUX_TYPE mux;
+        taskENTER_CRITICAL(&mux);
+        Callbacks.push_front(this);
+        taskEXIT_CRITICAL(&mux);
+    #else
+        taskENTER_CRITICAL();
+        Callbacks.push_front(this);
+        taskEXIT_CRITICAL();
+    #endif
 }
 
 
 void TickHook::Disable()
 {
-    taskENTER_CRITICAL();
-    Enabled = false;
-    taskEXIT_CRITICAL();
+    #ifdef ESP_PLATFORM
+        portMUX_TYPE mux;
+        taskENTER_CRITICAL(&mux);
+        Enabled = false;
+        taskEXIT_CRITICAL(&mux);
+    #else
+        taskENTER_CRITICAL();
+        Enabled = false;
+        taskEXIT_CRITICAL();
+    #endif
+
 }
 
 
 void TickHook::Enable()
 {
-    taskENTER_CRITICAL();
-    Enabled = true;
-    taskEXIT_CRITICAL();
+    #ifdef ESP_PLATFORM
+        portMUX_TYPE mux;
+        taskENTER_CRITICAL(&mux);
+        Enabled = true;
+        taskEXIT_CRITICAL(&mux);
+    #else
+        taskENTER_CRITICAL();
+        Enabled = true;
+        taskEXIT_CRITICAL();
+    #endif
+
 }
 
 

--- a/library.json
+++ b/library.json
@@ -1,0 +1,50 @@
+{
+  "name": "freertos-addons",
+  "version": "1.6.1",
+  "description": "A collection of C++ wrappers encapsulating FreeRTOS functionality.",
+  "keywords": "c++, cpp, freertos, addons, freertos-addons, multithreading, rtos",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/kabot-io/freertos-addons.git"
+  },
+  "authors":
+  [
+    {
+      "name": "Michael Becker",
+      "url": "https://github.com/michaelbecker"
+    },
+    {
+      "name": "Danilo Pucci",
+      "url": "https://github.com/danilopucci"
+    },
+    {
+      "name": "Lukas Neverauskis",
+      "url": "https://github.com/lukasnee"
+    },
+    {
+      "name": "Christian Köhnenkamp",
+      "url": "https://github.com/kohnech"
+    },
+    {
+      "name": "Krzysztof Pochwała",
+      "url": "https://github.com/kpochwala"
+    }
+    
+  ],
+  "license": "MIT",
+  "homepage": "https://michaelbecker.github.io/freertos-addons/",
+  "dependencies": {
+  },
+  "frameworks": "arduino",
+  "platforms": "espressif32",
+  "build": {
+    "srcDir": ".",
+    "srcFilter": "+<*> -<Linux>",
+    "includeDir": ".",
+    "flags": [
+      "-I c/Source/include",
+      "-I c++/Source/include"
+    ]
+  }
+}


### PR DESCRIPTION
Hi, i wanted to use Your library in platformio with ESP32-S3 running Espressif fork of FreeRTOS with support for ESP32 and ESP32-S3 dual-core MCUs. It turned out, that in their fork `taskENTER_CRITICAL()`  and `taskEXIT_CRITICAL()` have to take `mux` parameter, I suppose due to the "dual-coreness" nature. I've guarded the fix with `ESP_PLATFORM` defines, which are defined in their fork: [taskENTER()](https://github.com/espressif/arduino-esp32/blob/master/tools/sdk/esp32s3/include/freertos/include/freertos/task.h#L222), [taskEXIT()](https://github.com/espressif/arduino-esp32/blob/master/tools/sdk/esp32s3/include/freertos/include/freertos/task.h#L252).

I've also added `library.json` file manifest which describes how platformio should build the code, compatibility stuff and other metadata, such as authors and license. 

Feel free to merge or not :) I wanted to open this PR especially because I've seen in the issues that there were questions about support for Arduino and PlatformIO.

For now, if anybody want to use it in platformio, add it into `lib_deps` following way:

```ini
lib_deps =
    ...
    https://github.com/kabot-io/freertos-addons
```

PS. [Contributing guidelines](https://github.com/michaelbecker/freertos-addons/blob/dce1b8ce15b46fac10b5ffa19fa6807d4193dccd/CONTRIBUTING.md) still mention that the code is on GPL ;) 