### PR TITLE
Bugfix/workqueue crash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Minimum required version of CMake
+cmake_minimum_required(VERSION 3.12)
+ 
+# Define the project name, version, and language
+project(FreertosAddonsLibrary VERSION 1.0 LANGUAGES CXX)
+ 
+# Set the target library name
+set(TARGET_NAME freertos-addons)
+ 
+set (FREE_RTOS_ROOT "../freertos")
+ 
+# Specify the source files for the freertos-addons library
+set(FREERTOS_ADDONS_SRC_FILES
+    ${CMAKE_CURRENT_LIST_DIR}/c++/Source/ccondition_variable.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/c++/Source/cevent_groups.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/c++/Source/cmem_pool.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/c++/Source/cmutex.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/c++/Source/cqueue.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/c++/Source/cread_write_lock.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/c++/Source/csemaphore.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/c++/Source/ctasklet.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/c++/Source/cthread.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/c++/Source/ctickhook.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/c++/Source/ctimer.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/c++/Source/cworkqueue.cpp
+)
+ 
+# Define the include directories for the freertos-addons library
+set(FREERTOS_ADDONS_INCLUDE_DIRS
+    ${CMAKE_CURRENT_LIST_DIR}/c++/Source/include
+	${FREE_RTOS_ROOT}/include
+    ${FREE_RTOS_ROOT}/portable/GCC/ARM_CM4F
+)
+ 
+# Create the library target
+add_library(${TARGET_NAME} STATIC ${FREERTOS_ADDONS_SRC_FILES})
+ 
+# Define the include directories for the library
+target_include_directories(${TARGET_NAME} PUBLIC ${FREERTOS_ADDONS_INCLUDE_DIRS})
+ 
+ 
+# Optionally: Pass the include directories to the parent scope
+set(FREERTOS_ADDONS_INCLUDE_DIRS ${FREERTOS_ADDONS_INCLUDE_DIRS} PARENT_SCOPE)
+ 
+# Optionally: Define additional compiler properties (e.g., C++ standard)
+# set_target_properties(${TARGET_NAME} PROPERTIES CXX_STANDARD 11)

--- a/Linux/Demo/Linux_g++_dynamic_tasks/main.cpp
+++ b/Linux/Demo/Linux_g++_dynamic_tasks/main.cpp
@@ -141,7 +141,7 @@ class RootThread : public Thread {
                         break;
 
                     case 3: {
-                        char nameBuf[10];
+                        char nameBuf[14];
                         sprintf(nameBuf, "dy%d", ++threadCnt);
                         cout << GetName() << " Creating " << nameBuf << endl;
                         dt = new DynamicThread(nameBuf, 1);

--- a/Linux/Demo/Linux_g++_dynamic_tasks_high_pri/main.cpp
+++ b/Linux/Demo/Linux_g++_dynamic_tasks_high_pri/main.cpp
@@ -141,7 +141,7 @@ class RootThread : public Thread {
                         break;
 
                     case 3: {
-                        char nameBuf[10];
+                        char nameBuf[14];
                         sprintf(nameBuf, "dy%d", ++threadCnt);
                         cout << GetName() << " Creating " << nameBuf << endl;
                         dt = new DynamicThread(nameBuf, 1);

--- a/Linux/Demo/Linux_g++_dynamic_tasks_multistart_scheduler_on/main.cpp
+++ b/Linux/Demo/Linux_g++_dynamic_tasks_multistart_scheduler_on/main.cpp
@@ -143,7 +143,7 @@ class RootThread : public Thread {
                 switch (count) {
 
                     case 1: {
-                        char nameBuf[10];
+                        char nameBuf[16];
                         sprintf(nameBuf, "dy%d.%d", DelayInSeconds, ++threadCnt);
                         cout << GetName() << " Creating " << nameBuf << endl;
                         dt = new DynamicThread(nameBuf, 1);

--- a/c++/Source/cevent_groups.cpp
+++ b/c++/Source/cevent_groups.cpp
@@ -46,24 +46,11 @@ using namespace cpp_freertos;
 
 EventGroup::EventGroup()
 {
-    handle = xEventGroupCreate();
-
-    if (handle == NULL) {
-#ifndef CPP_FREERTOS_NO_EXCEPTIONS
-        throw EventGroupCreateException();
-#else
-        configASSERT(!"EventGroup Constructor Failed");
-#endif
-    }
-
-}
-
-
 #if( configSUPPORT_STATIC_ALLOCATION == 1 )
-
-EventGroup::EventGroup(StaticEventGroup_t *pxEventGroupBuffer)
-{
-    handle = xEventGroupCreateStatic(pxEventGroupBuffer);
+    handle = xEventGroupCreateStatic(&event_group_data);
+#else
+    handle = xEventGroupCreate();
+#endif
 
     if (handle == NULL) {
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS
@@ -73,8 +60,6 @@ EventGroup::EventGroup(StaticEventGroup_t *pxEventGroupBuffer)
 #endif
     }
 }
-
-#endif /* configSUPPORT_STATIC_ALLOCATION */
 
 
 EventGroup::~EventGroup()
@@ -115,12 +100,14 @@ EventBits_t EventGroup::ClearBits(const EventBits_t uxBitsToClear)
     return xEventGroupClearBits(handle, uxBitsToClear);
 }
 
+#if ( ( configUSE_TRACE_FACILITY == 1 ) && ( INCLUDE_xTimerPendFunctionCall == 1 ) && ( configUSE_TIMERS == 1 ) )
 
 BaseType_t EventGroup::ClearBitsFromISR(const EventBits_t uxBitsToClear)
 {
     return xEventGroupClearBitsFromISR(handle, uxBitsToClear);
 }
 
+#endif
 
 EventBits_t EventGroup::GetBits()
 {

--- a/c++/Source/cmem_pool.cpp
+++ b/c++/Source/cmem_pool.cpp
@@ -95,6 +95,7 @@ void MemoryPool::CalculateItemSize()
     }
 }
 
+#if( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
 
 MemoryPool::MemoryPool( int itemSize,
                         int itemCount,
@@ -120,10 +121,11 @@ MemoryPool::MemoryPool( int itemSize,
         FreeItems.push_back(address);
         address += ItemSize;
     }
-
-    Lock = new MutexStandard();
 }
 
+#endif /* configSUPPORT_DYNAMIC_ALLOCATION */
+
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
 
 MemoryPool::MemoryPool( int itemSize,
                         void *preallocatedMemory,
@@ -144,14 +146,14 @@ MemoryPool::MemoryPool( int itemSize,
         address += ItemSize;
         preallocatedMemorySize -= ItemSize;
     }
-
-    Lock = new MutexStandard();
 }
+
+#endif /* configSUPPORT_STATIC_ALLOCATION */
 
 
 void *MemoryPool::Allocate()
 {
-    LockGuard guard(*Lock);
+    LockGuard guard(Lock);
 
     if (FreeItems.empty())
         return NULL;
@@ -165,7 +167,7 @@ void *MemoryPool::Allocate()
 
 void MemoryPool::Free(void *item)
 {
-    LockGuard guard(*Lock);
+    LockGuard guard(Lock);
     FreeItems.push_back(item);
 }
 
@@ -184,7 +186,7 @@ void MemoryPool::AddMemory(int itemCount)
 
     for (int i = 0; i < itemCount; i++) {
 
-        LockGuard guard(*Lock);
+        LockGuard guard(Lock);
 
         FreeItems.push_back(address);
         address += ItemSize;
@@ -199,7 +201,7 @@ void MemoryPool::AddMemory( void *preallocatedMemory,
 
     while (preallocatedMemorySize >= ItemSize) {
 
-        LockGuard guard(*Lock);
+        LockGuard guard(Lock);
 
         FreeItems.push_back(address);
         address += ItemSize;

--- a/c++/Source/cmutex.cpp
+++ b/c++/Source/cmutex.cpp
@@ -59,7 +59,11 @@ Mutex::~Mutex()
 
 MutexStandard::MutexStandard()
 {
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+    handle = xSemaphoreCreateMutexStatic(&MutexBuffer);
+#else
     handle = xSemaphoreCreateMutex();
+#endif
 
     if (handle == NULL) {
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS
@@ -89,7 +93,11 @@ bool MutexStandard::Unlock()
 
 MutexRecursive::MutexRecursive()
 {
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+    handle = xSemaphoreCreateRecursiveMutexStatic(&MutexBuffer);
+#else
     handle = xSemaphoreCreateRecursiveMutex();
+#endif
 
     if (handle == NULL) {
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS

--- a/c++/Source/cqueue.cpp
+++ b/c++/Source/cqueue.cpp
@@ -45,6 +45,7 @@
 
 using namespace cpp_freertos;
 
+#if( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
 
 Queue::Queue(UBaseType_t maxItems, UBaseType_t itemSize)
 {
@@ -59,6 +60,24 @@ Queue::Queue(UBaseType_t maxItems, UBaseType_t itemSize)
     }
 }
 
+#endif
+
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+
+Queue::Queue(UBaseType_t maxItems, UBaseType_t itemSize, void *buffer)
+{
+    handle = xQueueCreateStatic(maxItems, itemSize, static_cast<uint8_t*>(buffer), &queue_buffer);
+
+    if (handle == NULL) {
+#ifndef CPP_FREERTOS_NO_EXCEPTIONS
+        throw QueueCreateException();
+#else
+        configASSERT(!"Queue Constructor Failed");
+#endif
+    }
+}
+
+#endif
 
 Queue::~Queue()
 {
@@ -170,10 +189,24 @@ UBaseType_t Queue::NumSpacesLeft()
 }
 
 
+#if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+
 Deque::Deque(UBaseType_t maxItems, UBaseType_t itemSize)
     : Queue(maxItems, itemSize)
 {
 }
+
+#endif
+
+
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+
+Deque::Deque(UBaseType_t maxItems, UBaseType_t itemSize, uint8_t * buffer)
+    : Queue(maxItems, itemSize, buffer)
+{
+}
+
+#endif
 
 
 bool Deque::EnqueueToFront(void *item, TickType_t Timeout)
@@ -196,10 +229,25 @@ bool Deque::EnqueueToFrontFromISR(void *item, BaseType_t *pxHigherPriorityTaskWo
 }
 
 
+
+#if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+
 BinaryQueue::BinaryQueue(UBaseType_t itemSize)
     : Queue(1, itemSize)
 {
 }
+
+#endif
+
+
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+
+BinaryQueue::BinaryQueue(UBaseType_t itemSize, uint8_t * buffer)
+    : Queue(1, itemSize, buffer)
+{
+}
+
+#endif
 
 
 bool BinaryQueue::Enqueue(const void *item)

--- a/c++/Source/cqueue.cpp
+++ b/c++/Source/cqueue.cpp
@@ -202,14 +202,14 @@ BinaryQueue::BinaryQueue(UBaseType_t itemSize)
 }
 
 
-bool BinaryQueue::Enqueue(void *item)
+bool BinaryQueue::Enqueue(const void *item)
 {
     (void)xQueueOverwrite(handle, item);
     return true;
 }
 
 
-bool BinaryQueue::EnqueueFromISR(void *item, BaseType_t *pxHigherPriorityTaskWoken)
+bool BinaryQueue::EnqueueFromISR(const void *item, BaseType_t *pxHigherPriorityTaskWoken)
 {
     (void)xQueueOverwriteFromISR(handle, item, pxHigherPriorityTaskWoken);
     return true;

--- a/c++/Source/cread_write_lock.cpp
+++ b/c++/Source/cread_write_lock.cpp
@@ -49,7 +49,11 @@ using namespace cpp_freertos;
 ReadWriteLock::ReadWriteLock()
     : ReadCount(0)
 {
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+    ReadLock = xSemaphoreCreateMutexStatic(&ReadLockMutexBuffer);
+#else
     ReadLock = xSemaphoreCreateMutex();
+#endif
     if (ReadLock == NULL) {
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS
         throw ReadWriteLockCreateException();
@@ -65,7 +69,11 @@ ReadWriteLock::ReadWriteLock()
     //  of unlocks when multiple threads hold the reader lock. 
     //  Semaphores are not subject to this constraint.
     //
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    ResourceLock = xSemaphoreCreateBinaryStatic(&ResourceLockSemaphoreBuffer);
+#elif ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
     ResourceLock = xSemaphoreCreateBinary();
+#endif
     if (ResourceLock == NULL) {
         vSemaphoreDelete(ReadLock);
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS
@@ -131,7 +139,11 @@ ReadWriteLockPreferWriter::ReadWriteLockPreferWriter()
     : ReadWriteLock(),
       WriteCount(0)
 {
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+    WriteLock = xSemaphoreCreateMutexStatic(&WriteLockMutexBuffer);
+#else
     WriteLock = xSemaphoreCreateMutex();
+#endif
     if (WriteLock == NULL) {
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS
         throw ReadWriteLockCreateException();
@@ -147,7 +159,11 @@ ReadWriteLockPreferWriter::ReadWriteLockPreferWriter()
     //  of unlocks when multiple threads hold the reader lock. 
     //  Semaphores are not subject to this constraint.
     //
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    BlockReadersLock = xSemaphoreCreateBinaryStatic(&BlockReadersLockSemaphoreBuffer);
+#elif ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
     BlockReadersLock = xSemaphoreCreateBinary();
+#endif
     if (BlockReadersLock == NULL) {
         vSemaphoreDelete(WriteLock);
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS

--- a/c++/Source/csemaphore.cpp
+++ b/c++/Source/csemaphore.cpp
@@ -99,7 +99,11 @@ Semaphore::~Semaphore()
 
 BinarySemaphore::BinarySemaphore(bool set)
 {
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    handle = xSemaphoreCreateBinaryStatic(&semaphore_buffer);
+#elif ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
     handle = xSemaphoreCreateBinary();
+#endif
 
     if (handle == NULL) {
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS
@@ -114,6 +118,7 @@ BinarySemaphore::BinarySemaphore(bool set)
     }
 }
 
+#if ( configUSE_COUNTING_SEMAPHORES == 1 )
 
 CountingSemaphore::CountingSemaphore(UBaseType_t maxCount, UBaseType_t initialCount)
 {
@@ -133,7 +138,11 @@ CountingSemaphore::CountingSemaphore(UBaseType_t maxCount, UBaseType_t initialCo
 #endif
     }
 
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    handle = xSemaphoreCreateCountingStatic(maxCount, initialCount, &semaphore_buffer);
+#elif ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
     handle = xSemaphoreCreateCounting(maxCount, initialCount);
+#endif
 
     if (handle == NULL) {
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS
@@ -145,3 +154,4 @@ CountingSemaphore::CountingSemaphore(UBaseType_t maxCount, UBaseType_t initialCo
 }
 
 
+#endif  // ( configUSE_COUNTING_SEMAPHORES == 1 )

--- a/c++/Source/ctasklet.cpp
+++ b/c++/Source/ctasklet.cpp
@@ -48,7 +48,11 @@ using namespace cpp_freertos;
 
 Tasklet::Tasklet()
 {
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+    DtorLock = xSemaphoreCreateBinaryStatic(&DtorLockSemaphoreBuffer);
+#else
     DtorLock = xSemaphoreCreateBinary();
+#endif
 
     if (DtorLock == NULL) {
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS

--- a/c++/Source/cthread.cpp
+++ b/c++/Source/cthread.cpp
@@ -325,8 +325,11 @@ void Thread::Cleanup()
 
 Thread::~Thread()
 {
-    vTaskDelete(handle);
-    handle = (TaskHandle_t)-1;
+    if (ThreadStarted && handle != NULL) {
+        // thread is only created if it is started so only delete if it was started    
+        vTaskDelete(handle);
+        handle = NULL;
+    }
 }
 
 #else

--- a/c++/Source/ctimer.cpp
+++ b/c++/Source/ctimer.cpp
@@ -51,11 +51,20 @@ Timer::Timer(   const char * const TimerName,
                 bool Periodic
                 )
 {
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    handle = xTimerCreateStatic(  TimerName,
+                                  PeriodInTicks,
+                                  Periodic ? pdTRUE : pdFALSE,
+                                  this,
+                                  TimerCallbackFunctionAdapter,
+                                  &timer_buffer);
+#else
     handle = xTimerCreate(  TimerName,
                             PeriodInTicks,
                             Periodic ? pdTRUE : pdFALSE,
                             this,
                             TimerCallbackFunctionAdapter);
+#endif
 
     if (handle == NULL) {
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS
@@ -71,11 +80,20 @@ Timer::Timer(   TickType_t PeriodInTicks,
                 bool Periodic
                 )
 {
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    handle = xTimerCreateStatic(  "Default",
+                                  PeriodInTicks,
+                                  Periodic ? pdTRUE : pdFALSE,
+                                  this,
+                                  TimerCallbackFunctionAdapter,
+                                  &timer_buffer);
+#elif ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
     handle = xTimerCreate(  "Default",
                             PeriodInTicks,
                             Periodic ? pdTRUE : pdFALSE,
                             this,
                             TimerCallbackFunctionAdapter);
+#endif
 
     if (handle == NULL) {
 #ifndef CPP_FREERTOS_NO_EXCEPTIONS

--- a/c++/Source/cworkqueue.cpp
+++ b/c++/Source/cworkqueue.cpp
@@ -232,7 +232,7 @@ void WorkQueue::CWorkerThread::Run()
             //
             //  Exit the task loop.
             //
-            break;
+            continue;
         }
 
         //
@@ -254,4 +254,3 @@ void WorkQueue::CWorkerThread::Run()
     //
     ParentWorkQueue.ThreadComplete.Give();
 }
-

--- a/c++/Source/cworkqueue.cpp
+++ b/c++/Source/cworkqueue.cpp
@@ -143,18 +143,6 @@ WorkQueue::~WorkQueue()
     //  Note that we cannot flush the queue. If there are items 
     //  in the queue maked freeAfterComplete, we would leak the 
     //  memory. 
-    //
-
-    //
-    //  Send a message that it's time to cleanup.
-    //
-    WorkItem *work = NULL;
-    WorkItemQueue.Enqueue(&work);
-
-    //
-    //  Wait until the thread has run enough to signal that it's done.
-    //
-    ThreadComplete.Take();
 }
 
 #endif

--- a/c++/Source/include/event_groups.hpp
+++ b/c++/Source/include/event_groups.hpp
@@ -59,6 +59,9 @@
 #include "FreeRTOS.h"
 #include "event_groups.h"
 
+#if ( configSUPPORT_STATIC_ALLOCATION != 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION != 1 )
+#error "FreeRTOS-Addons requires either configSUPPORT_STATIC_ALLOCATION or configSUPPORT_DYNAMIC_ALLOCATION"
+#endif
 
 namespace cpp_freertos {
 
@@ -122,12 +125,6 @@ class EventGroup {
          */
         EventGroup();
 
-#if( configSUPPORT_STATIC_ALLOCATION == 1 )
-        /**
-         *  Construct a Event Group with static allocation
-         */
-        EventGroup(StaticEventGroup_t *pxEventGroupBuffer);
-#endif
         /**
          *  Allow two or more tasks to use an event group to sync each other.
          *
@@ -241,6 +238,7 @@ class EventGroup {
         */
         EventBits_t GetBits();
 
+        #if ( ( configUSE_TRACE_FACILITY == 1 ) && ( INCLUDE_xTimerPendFunctionCall == 1 ) && ( configUSE_TIMERS == 1 ) )
         /**
          *  Returns the current value of the event bits (event flags) in an
          *  event group from ISR context.
@@ -249,6 +247,8 @@ class EventGroup {
          *  time EventGroup::GetBitsFromISR was called.
          */
         EventBits_t GetBitsFromISR();
+
+        #endif
 
         /**
          *  Set bits (flags) within an event group.
@@ -302,6 +302,14 @@ class EventGroup {
          *  FreeRTOS Event Group handle.
          */
         EventGroupHandle_t handle;
+
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+        /**
+         * FreeRTOS Event Group structure for static allocation of storage
+         * for data associated with the event group.
+         */
+    StaticEventGroup_t event_group_data;
+#endif
 
 };
 

--- a/c++/Source/include/mem_pool.hpp
+++ b/c++/Source/include/mem_pool.hpp
@@ -62,6 +62,10 @@
 #include "FreeRTOS.h"
 #include "mutex.hpp"
 
+#if ( configSUPPORT_STATIC_ALLOCATION != 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION != 1 )
+#error "FreeRTOS-Addons requires either configSUPPORT_STATIC_ALLOCATION or configSUPPORT_DYNAMIC_ALLOCATION"
+#endif
+
 namespace cpp_freertos {
 
 
@@ -149,6 +153,8 @@ class MemoryPool {
     /////////////////////////////////////////////////////////////////////////
     public:
 
+#if( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+
         /**
          *  Constructor to create a Memory Pool.
          *
@@ -166,6 +172,11 @@ class MemoryPool {
         MemoryPool( int itemSize,
                     int itemCount,
                     int alignment);
+
+#endif /* configSUPPORT_DYNAMIC_ALLOCATION */
+
+
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
 
         /**
          *  Constructor to create a Memory Pool.
@@ -186,6 +197,9 @@ class MemoryPool {
                     void *preallocatedMemory,
                     int preallocatedMemorySize,
                     int alignment);
+
+#endif /* configSUPPORT_STATIC_ALLOCATION */
+
 
         /**
          *  Allows you to add memory to a MemoryPool.
@@ -236,7 +250,7 @@ class MemoryPool {
         /**
          *  Standard Mutex to allow thread safety.
          */
-        Mutex *Lock;
+        MutexStandard Lock;
 
         /**
          *  Save the item size for additions.

--- a/c++/Source/include/mutex.hpp
+++ b/c++/Source/include/mutex.hpp
@@ -61,6 +61,10 @@
 #include "FreeRTOS.h"
 #include "semphr.h"
 
+#if ( configSUPPORT_STATIC_ALLOCATION != 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION != 1 )
+#error "FreeRTOS-Addons requires either configSUPPORT_STATIC_ALLOCATION or configSUPPORT_DYNAMIC_ALLOCATION"
+#endif
+
 namespace cpp_freertos {
 
 
@@ -199,6 +203,15 @@ class MutexStandard : public Mutex {
          *           if it fails, did you call Lock() first?)
          */
         virtual bool Unlock();
+
+    private:
+
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+        /**
+         * Underlying static semaphore.
+         */
+        StaticSemaphore_t MutexBuffer;
+#endif
 };
 
 
@@ -247,6 +260,15 @@ class MutexRecursive : public Mutex {
          *           if it fails, did you call Lock() first?)
          */
         virtual bool Unlock();
+
+    private:
+
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+        /**
+         * Underlying static semaphore.
+         */
+        StaticSemaphore_t MutexBuffer;
+#endif
 };
 
 #endif

--- a/c++/Source/include/queue.hpp
+++ b/c++/Source/include/queue.hpp
@@ -61,6 +61,9 @@
 #include "FreeRTOS.h"
 #include "queue.h"
 
+#if ( configSUPPORT_STATIC_ALLOCATION != 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION != 1 )
+#error "FreeRTOS-Addons requires either configSUPPORT_STATIC_ALLOCATION or configSUPPORT_DYNAMIC_ALLOCATION"
+#endif
 
 namespace cpp_freertos {
 
@@ -123,6 +126,9 @@ class Queue {
     //
     /////////////////////////////////////////////////////////////////////////
     public:
+
+#if( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+
         /**
          *  Our constructor.
          *
@@ -132,6 +138,23 @@ class Queue {
          *  @note FreeRTOS queues use a memcpy / fixed size scheme for queues.
          */
         Queue(UBaseType_t maxItems, UBaseType_t itemSize);
+
+#endif /* configSUPPORT_DYNAMIC_ALLOCATION */
+
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+
+        /**
+         *  Our constructor.
+         *
+         *  @throws QueueCreateException
+         *  @param maxItems Maximum number of items this queue can hold.
+         *  @param itemSize Size of an item in a queue.
+         *  @param buffer A buffer to use for the queue.
+         *  @note FreeRTOS queues use a memcpy / fixed size scheme for queues.
+         */
+        Queue(UBaseType_t maxItems, UBaseType_t itemSize, void *buffer);
+
+#endif /* configSUPPORT_STATIC_ALLOCATION */
 
         /**
          *  Our destructor.
@@ -248,6 +271,14 @@ class Queue {
          *  FreeRTOS queue handle.
          */
         QueueHandle_t handle;
+
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+        /**
+         *  FreeRTOS static queue data structure.
+         */
+        StaticQueue_t queue_buffer;
+
+#endif
 };
 
 
@@ -268,6 +299,9 @@ class Deque : public Queue {
     //
     /////////////////////////////////////////////////////////////////////////
     public:
+
+#if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+
         /**
          *  Our constructor.
          *
@@ -277,6 +311,23 @@ class Deque : public Queue {
          *  @note FreeRTOS queues use a memcpy / fixed size scheme for queues.
          */
         Deque(UBaseType_t maxItems, UBaseType_t itemSize);
+
+#endif
+
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+
+        /**
+         *  Our constructor.
+         *
+         *  @throws QueueCreateException
+         *  @param maxItems Maximum number of items thsi queue can hold.
+         *  @param itemSize Size of an item in a queue.
+         *  @param buffer A buffer to use for the queue.
+         *  @note FreeRTOS queues use a memcpy / fixed size scheme for queues.
+         */
+        Deque(UBaseType_t maxItems, UBaseType_t itemSize, uint8_t * buffer);
+
+#endif
 
         /**
          *  Add an item to the front of the queue. This will result in
@@ -321,6 +372,9 @@ class BinaryQueue : public Queue {
     //
     /////////////////////////////////////////////////////////////////////////
     public:
+
+#if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+
         /**
          *  Our constructor.
          *
@@ -329,6 +383,22 @@ class BinaryQueue : public Queue {
          *  @note FreeRTOS queues use a memcpy / fixed size scheme for queues.
          */
         explicit BinaryQueue(UBaseType_t itemSize);
+
+#endif
+
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+
+        /**
+         *  Our constructor.
+         *
+         *  @throws QueueCreateException
+         *  @param itemSize Size of an item in a queue.
+         *  @param buffer A buffer to use for the queue.
+         *  @note FreeRTOS queues use a memcpy / fixed size scheme for queues.
+         */
+        explicit BinaryQueue(UBaseType_t itemSize, uint8_t * buffer);
+
+#endif
 
          /**
           *  Add an item to the queue.

--- a/c++/Source/include/queue.hpp
+++ b/c++/Source/include/queue.hpp
@@ -336,7 +336,7 @@ class BinaryQueue : public Queue {
           *  @param item The item you are adding.
           *  @return true always, because of overwrite.
           */
-        virtual bool Enqueue(void *item);
+        virtual bool Enqueue(const void *item);
 
          /**
           *  Add an item to the queue in ISR context.
@@ -346,7 +346,7 @@ class BinaryQueue : public Queue {
           *         rescheduling event.
           *  @return true always, because of overwrite.
           */
-        virtual bool EnqueueFromISR(void *item, BaseType_t *pxHigherPriorityTaskWoken);
+        virtual bool EnqueueFromISR(const void *item, BaseType_t *pxHigherPriorityTaskWoken);
 };
 
 

--- a/c++/Source/include/read_write_lock.hpp
+++ b/c++/Source/include/read_write_lock.hpp
@@ -62,6 +62,9 @@
 #include "FreeRTOS.h"
 #include "semphr.h"
 
+#if ( configSUPPORT_STATIC_ALLOCATION != 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION != 1 )
+#error "FreeRTOS-Addons requires either configSUPPORT_STATIC_ALLOCATION or configSUPPORT_DYNAMIC_ALLOCATION"
+#endif
 
 namespace cpp_freertos {
 
@@ -174,6 +177,18 @@ class ReadWriteLock {
          *  from Reader access when a writer is changing something.
          */
         SemaphoreHandle_t ResourceLock;
+
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+        /**
+         * Underlying static semaphore.
+         */
+        StaticSemaphore_t ReadLockMutexBuffer;
+
+        /**
+         * Underlying static semaphore.
+         */
+        StaticSemaphore_t ResourceLockSemaphoreBuffer;
+#endif
 };
 
 
@@ -281,6 +296,19 @@ class ReadWriteLockPreferWriter : public ReadWriteLock {
          *  Lock to stop reader threads from starving a Writer.
          */
         SemaphoreHandle_t BlockReadersLock;
+
+#if( configSUPPORT_STATIC_ALLOCATION == 1 )
+        /**
+         * Underlying static semaphore.
+         */
+        StaticSemaphore_t WriteLockMutexBuffer;
+
+        /**
+         * Underlying static semaphore.
+         */
+        StaticSemaphore_t BlockReadersLockSemaphoreBuffer;
+#endif
+
 };
 
 

--- a/c++/Source/include/semaphore.hpp
+++ b/c++/Source/include/semaphore.hpp
@@ -61,6 +61,9 @@
 #include "FreeRTOS.h"
 #include "semphr.h"
 
+#if ( configSUPPORT_STATIC_ALLOCATION != 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION != 1 )
+#error "FreeRTOS-Addons requires either configSUPPORT_STATIC_ALLOCATION or configSUPPORT_DYNAMIC_ALLOCATION"
+#endif
 
 namespace cpp_freertos {
 
@@ -188,6 +191,13 @@ class Semaphore {
          *  directly created, this is a base class only.
          */
         Semaphore();
+
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+        /**
+         * Underlying static semaphore.
+         */
+        StaticSemaphore_t semaphore_buffer;
+#endif
 };
 
 
@@ -212,6 +222,7 @@ class BinarySemaphore : public Semaphore {
         explicit BinarySemaphore(bool set = false);
 };
 
+#if ( configUSE_COUNTING_SEMAPHORES == 1 )
 
 /**
  *  Wrapper class for Counting Semaphores.
@@ -236,6 +247,7 @@ class CountingSemaphore : public Semaphore {
         CountingSemaphore(UBaseType_t maxCount, UBaseType_t initialCount);
 };
 
+#endif
 
 }
 #endif

--- a/c++/Source/include/tasklet.hpp
+++ b/c++/Source/include/tasklet.hpp
@@ -63,6 +63,9 @@
 #include "timers.h"
 #include "semphr.h"
 
+#if ( configSUPPORT_STATIC_ALLOCATION != 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION != 1 )
+#error "FreeRTOS-Addons requires either configSUPPORT_STATIC_ALLOCATION or configSUPPORT_DYNAMIC_ALLOCATION"
+#endif
 
 namespace cpp_freertos {
 
@@ -210,6 +213,13 @@ class Tasklet {
          *  Protect against accidental deletion before we were executed.
          */
         SemaphoreHandle_t DtorLock;
+
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+        /**
+         * Underlying static semaphore.
+         */
+        StaticSemaphore_t DtorLockSemaphoreBuffer;
+#endif
 };
 
 }

--- a/c++/Source/include/thread.hpp
+++ b/c++/Source/include/thread.hpp
@@ -62,6 +62,10 @@
 #include "semaphore.hpp"
 #include "condition_variable.hpp"
 
+#if ( configSUPPORT_STATIC_ALLOCATION != 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION != 1 )
+#error "FreeRTOS-Addons requires either configSUPPORT_STATIC_ALLOCATION or configSUPPORT_DYNAMIC_ALLOCATION"
+#endif
+
 namespace cpp_freertos {
 
 
@@ -87,6 +91,9 @@ class Thread {
     //
     /////////////////////////////////////////////////////////////////////////
     public:
+
+#if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+
         /**
          *  Constructor to create a named thread.
          *
@@ -112,6 +119,43 @@ class Thread {
          */
         Thread( uint16_t StackDepth,
                 UBaseType_t Priority);
+
+#endif
+
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+
+        /**
+         *  Constructor to create a named thread.
+         *
+         *  @param Name Name of the thread. Only useful for debugging.
+         *  @param StackDepth Number of "words" allocated for the Thread stack.
+         *  @param StackBuffer Pointer to preallocated stack space.
+         *  @param Priority FreeRTOS priority of this Thread.
+         */
+#ifndef CPP_FREERTOS_NO_CPP_STRINGS
+        Thread( const std::string Name,
+                uint16_t StackDepth,
+                StackType_t * const StackBuffer,
+                UBaseType_t Priority);
+#else
+        Thread( const char *Name,
+                uint16_t StackDepth,
+                StackType_t * const StackBuffer,
+                UBaseType_t Priority);
+#endif
+
+        /**
+         *  Constructor to create an unnamed thread.
+         *
+         *  @param StackDepth Number of "words" allocated for the Thread stack.
+         *  @param StackBuffer Pointer to preallocated stack space.
+         *  @param Priority FreeRTOS priority of this Thread.
+         */
+        Thread( uint16_t StackDepth,
+                StackType_t * const StackBuffer,
+                UBaseType_t Priority);
+#endif
+
 
         /**
          *  Starts a thread.
@@ -394,6 +438,18 @@ class Thread {
          *  Stack depth of this Thread, in words.
          */
         const uint16_t StackDepth;
+
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+        /**
+         * Pointer to preallocated stack space.
+         */
+        StackType_t * const StackBuffer;
+
+        /**
+         * Static task buffer for this Thread.
+         */
+        StaticTask_t TaskBuffer;
+#endif
 
         /**
          *  A saved / cached copy of what the Thread's priority is.

--- a/c++/Source/include/thread.hpp
+++ b/c++/Source/include/thread.hpp
@@ -195,6 +195,15 @@ class Thread {
         /**
          *  Yield the scheduler.
          */
+        #ifdef Yield
+            // The "winbase.h" header defines Yield as a macro, so we need
+            // to make sure we don't include any WINAPI headers when
+            // compiling this file. This should be handled by the correct
+            // inclusion (or non-inclusion) of headers by the MSVC-MingW
+            // FreeRTOS port (i.e. portmacro.h should be kept free of any
+            // WINAPI pollutions.
+            #error "Yield has been defined as a macro."
+        #endif		 
         static inline void Yield()
         {
             taskYIELD();

--- a/c++/Source/include/timer.hpp
+++ b/c++/Source/include/timer.hpp
@@ -62,6 +62,9 @@
 #include "FreeRTOS.h"
 #include "timers.h"
 
+#if ( configSUPPORT_STATIC_ALLOCATION != 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION != 1 )
+#error "FreeRTOS-Addons requires either configSUPPORT_STATIC_ALLOCATION or configSUPPORT_DYNAMIC_ALLOCATION"
+#endif
 
 namespace cpp_freertos {
 
@@ -280,6 +283,13 @@ class Timer {
          *  Reference to the underlying timer handle.
          */
         TimerHandle_t handle;
+
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+        /**
+         * Underlying static timer.
+         */
+        StaticTimer_t timer_buffer;
+#endif
 
         /**
          *  Adapter function that allows you to write a class

--- a/c/Source/zero_copy_queue.c
+++ b/c/Source/zero_copy_queue.c
@@ -76,8 +76,8 @@ ZeroCopyQueue_t ZcqCreateQueue( int ItemSize,
 
     zcq->Pool = CreateMemoryPool(ItemSize, ItemCount, Alignment);
     if (zcq->Pool == NULL) {
-        free(zcq);
         vQueueDelete(zcq->Handle);
+        free(zcq);
         return NULL;
     }
 


### PR DESCRIPTION
###  **This PR address the issue of Hardfault due to Thread exit of WorkQueue.**

 Exiting the thread via break causes the task function to return, which triggers:
 1. prvTaskExitError() (see port.c line 228-249) - FreeRTOS task functions must never return
 2. The Idle task then attempts cleanup via prvCheckTasksWaitingTermination() (see tasks.c line 6074-6145)
    which tries to free the TCB while it may still be scheduled or in use
 3. Results in hardfault due to race condition in resource cleanup

 In C++, the situation is more complex than plain C:
 - The task is owned by a C++ object (cpp_freertos::Thread wrapper)
 - Task deletion (vTaskDelete) and object destruction (~Thread) are separate events
 - The ~Thread() destructor calls vTaskDelete(handle) (see cthread.cpp line 326-362)
 - If the task returns before destruction, vTaskDelete() may operate on an invalid/zombie task
 - Even calling vTaskDelete(NULL) from within Run() causes the task to be deleted while
   the destructor still holds a reference to it, leading to double-free or use-after-free

 Therefore, the safest approach for a C++ wrapper task is to keep the thread alive but allowing the destructor to properly clean up when the object is destroyed.